### PR TITLE
fix: Bukkit.getLogger() -> Plugin.getInstance().getLogger()

### DIFF
--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/SettingsLoad.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/SettingsLoad.java
@@ -142,7 +142,7 @@ public class SettingsLoad {
 
         new Processor().init();
 
-        Bukkit.getLogger().info("===Custom-Crafter data loaded.===");
+        CustomCrafter.getInstance().getLogger().info("===Custom-Crafter data loaded.===");
     }
 
     private void configFileDirectoryCheck(Path path){
@@ -158,10 +158,10 @@ public class SettingsLoad {
             }
 
             //dir.mkdir();
-            Bukkit.getLogger().info(String.format("Not found the directory \"%s\"."+ LINE_SEPARATOR +"So, the system made the directory named that.",path.toUri().toString()));
+            CustomCrafter.getInstance().getLogger().info(String.format("Not found the directory \"%s\"."+ LINE_SEPARATOR +"So, the system made the directory named that.",path.toUri().toString()));
         }else if(!path.toFile().isDirectory()){
-            Bukkit.getLogger().warning(String.format("The path \"%s\" is not a directory.",path.toUri().toString()));
-            Bukkit.getLogger().warning("You must fix this problem when before you use this plugin.");
+            CustomCrafter.getInstance().getLogger().warning(String.format("The path \"%s\" is not a directory.",path.toUri().toString()));
+            CustomCrafter.getInstance().getLogger().warning("You must fix this problem when before you use this plugin.");
 
             new BukkitRunnable(){
                 public void run(){
@@ -176,7 +176,7 @@ public class SettingsLoad {
         try {
             paths = Files.list(path);
         } catch (Exception e){
-            Bukkit.getLogger().warning("[CustomCrafter] Error: Cannot get files from "+path);
+            CustomCrafter.getInstance().getLogger().warning("Error: Cannot get files from "+path);
             return null;
         }
 
@@ -264,13 +264,13 @@ public class SettingsLoad {
                     // enchanted book
                     if(!candidate.isEmpty()){
                         //invalid pattern (candidate over only one)
-                        Bukkit.getLogger().info("[Custom Crafter] Matter load fail. - Candidate Quarrel -");
+                        CustomCrafter.getInstance().getLogger().info("[Custom Crafter] Matter load fail. - Candidate Quarrel -");
                         continue Top;
                     }
 
                     if(!config.contains("enchant") || config.getStringList("enchant").isEmpty()){
                         // invalid pattern (enchantments not contained -> identity lost)
-                        Bukkit.getLogger().info("[Custom Crafter] Matter load fail. - Identity Lost -");
+                        CustomCrafter.getInstance().getLogger().info("[Custom Crafter] Matter load fail. - Identity Lost -");
                         continue Top;
                     }
 
@@ -378,7 +378,7 @@ public class SettingsLoad {
         for(String str : config.getStringList("potion")){
             List<String> list = Arrays.asList(str.split(","));
             if(list.size() != 4) {
-                Bukkit.getLogger().warning("[Custom Crafter] Potion Configuration Parameter are not enough.");
+                CustomCrafter.getInstance().getLogger().warning("[Custom Crafter] Potion Configuration Parameter are not enough.");
                 return null;
             }
             PotionEffectType effectType = PotionEffectType.getByName(list.get(0).toUpperCase());
@@ -415,7 +415,7 @@ public class SettingsLoad {
             FileConfiguration config = YamlConfiguration.loadConfiguration(path.toFile());
 
             String name = config.getString("name");
-            Bukkit.getLogger().info("Now loading (Recipe Name): " + name);
+            CustomCrafter.getInstance().getLogger().info("Now loading (Recipe Name): " + name);
             String tag = config.getString("tag").toUpperCase();
             Result result = RESULTS.getOrDefault(config.getString("result"), PASS_THROUGH_RESULT);
 
@@ -542,14 +542,14 @@ public class SettingsLoad {
                             NAMED_RECIPES_MAP.remove(targetName);
                             LOCK_TASK_ID_WITH_RECIPE_NAME.remove(id);
 
-                            Bukkit.getLogger().info("[CustomCrafter] "+targetName+" is disabled now!");
+                            CustomCrafter.getInstance().getLogger().info(targetName+" is disabled now!");
                         }
                     };
                     runnable.runTaskLater(CustomCrafter.getInstance(), delayTicks);
                     int taskID = runnable.getTaskId();
                     LOCK_TASK_ID_WITH_RECIPE_NAME.put(taskID, name);
 
-                    Bukkit.getLogger().info(String.format("[CustomCrafter] Named Recipe=%s will be locked in %s", name, ZonedDateTime.parse(lockTimeRow).toString()));
+                    CustomCrafter.getInstance().getLogger().info(String.format("Named Recipe=%s will be locked in %s", name, ZonedDateTime.parse(lockTimeRow).toString()));
                 }
             }
 
@@ -572,7 +572,7 @@ public class SettingsLoad {
                             }
                             ITEM_PLACED_SLOTS_RECIPE_MAP.get(target.getContentsNoAir().size()).add(target);
 
-                            Bukkit.getLogger().info("[CustomCrafter] "+targetName+" is enabled now!");
+                            CustomCrafter.getInstance().getLogger().info(targetName+" is enabled now!");
                             REGISTERED_RECIPES.remove(targetName);
                             UNLOCK_TASK_ID_WITH_RECIPE_NAME.remove(id);
                         }
@@ -582,7 +582,7 @@ public class SettingsLoad {
                     REGISTERED_RECIPES.put(name, new Recipe(name, tag, coordinates, returns, result, permission, containers));
                     UNLOCK_TASK_ID_WITH_RECIPE_NAME.put(taskID, name);
 
-                    Bukkit.getLogger().info(String.format("[CustomCrafter] Named Recipe=%s will be unlocked in %s", name, ZonedDateTime.parse(unlockTimeRow).toString()));
+                    CustomCrafter.getInstance().getLogger().info(String.format("Named Recipe=%s will be unlocked in %s", name, ZonedDateTime.parse(unlockTimeRow).toString()));
                     continue;
                 }
             }
@@ -710,8 +710,8 @@ public class SettingsLoad {
             // yyyy-mm-ddThh:mm:ss+offset with UTC[TIMEZONE]
             zonedDateTime = ZonedDateTime.parse(dateRow);
         } catch (DateTimeParseException e) {
-            Bukkit.getLogger().warning("[CustomCrafter] An invalid DateTime format found. (from java.time.ZonedDateTime=DateTimeParseException)");
-            Bukkit.getLogger().info("[CustomCrafter] So, the system will not load this recipe and register to the list about auto "+(delete ? "" : "un")+"lock.");
+            CustomCrafter.getInstance().getLogger().warning("An invalid DateTime format found. (from java.time.ZonedDateTime=DateTimeParseException)");
+            CustomCrafter.getInstance().getLogger().info("So, the system will not load this recipe and register to the list about auto "+(delete ? "" : "un")+"lock.");
             return null;
         }
         ZonedDateTime now = ZonedDateTime.now();
@@ -721,10 +721,10 @@ public class SettingsLoad {
             try {
                 duration = Duration.between(zonedDateTime, now).abs();
             } catch (DateTimeException e) {
-                Bukkit.getLogger().warning("[CustomCrafter] The system cannot get times diff about now and unlock date. (DateTimeException)");
+                CustomCrafter.getInstance().getLogger().warning("The system cannot get times diff about now and unlock date. (DateTimeException)");
                 return null;
             } catch (ArithmeticException e) {
-                Bukkit.getLogger().warning("[CustomCrafter] The system could not register to "+(delete ? "" : "un")+"lock the recipe. (Diff times over the limit.)");
+                CustomCrafter.getInstance().getLogger().warning("The system could not register to "+(delete ? "" : "un")+"lock the recipe. (Diff times over the limit.)");
                 return null;
             }
             return duration;

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/command/File.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/command/File.java
@@ -1,5 +1,6 @@
 package com.github.sakakiaruka.customcrafter.customcrafter.command;
 
+import com.github.sakakiaruka.customcrafter.customcrafter.CustomCrafter;
 import com.github.sakakiaruka.customcrafter.customcrafter.util.PotionUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -9,10 +10,10 @@ import static com.github.sakakiaruka.customcrafter.customcrafter.SettingsLoad.LI
 
 public class File {
     public void defaultPotion() {
-        Bukkit.getLogger().info(BAR + LINE_SEPARATOR);
-        Bukkit.getLogger().info("The system is making default potion files.");
-        Bukkit.getLogger().info("Do not shutdown or stop a server.");
-        Bukkit.getLogger().info(LINE_SEPARATOR + BAR);
+        CustomCrafter.getInstance().getLogger().info(BAR + LINE_SEPARATOR);
+        CustomCrafter.getInstance().getLogger().info("The system is making default potion files.");
+        CustomCrafter.getInstance().getLogger().info("Do not shutdown or stop a server.");
+        CustomCrafter.getInstance().getLogger().info(LINE_SEPARATOR + BAR);
         PotionUtil.makeDefaultPotionFilesWrapper();
     }
 }

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/command/Help.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/command/Help.java
@@ -24,8 +24,8 @@ public class Help {
 
     public void one(String type, CommandSender sender) {
         if (!COMMAND_ARGS.contains(type)) {
-            sender.sendMessage("[CustomCrafter] The specified argument is not exist.");
-            sender.sendMessage("[CustomCrafter] Choose one from these. = "+COMMAND_ARGS);
+            sender.sendMessage("The specified argument is not exist.");
+            sender.sendMessage("Choose one from these. = "+COMMAND_ARGS);
             return;
         }
         sender.sendMessage(BAR);

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/command/PermissionCheck.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/command/PermissionCheck.java
@@ -1,5 +1,6 @@
 package com.github.sakakiaruka.customcrafter.customcrafter.command;
 
+import com.github.sakakiaruka.customcrafter.customcrafter.CustomCrafter;
 import com.github.sakakiaruka.customcrafter.customcrafter.object.Permission.RecipePermission;
 import com.github.sakakiaruka.customcrafter.customcrafter.util.RecipePermissionUtil;
 import org.bukkit.Bukkit;
@@ -34,7 +35,7 @@ public class PermissionCheck {
         if (RecipePermissionUtil.hasPermission(permission,player)) return;
         if (!PLAYER_PERMISSIONS.containsKey(uuid)) PLAYER_PERMISSIONS.put(uuid,new HashSet<>());
         PLAYER_PERMISSIONS.get(uuid).add(permission);
-        Bukkit.getLogger().info(String.format("Permission added: %s  Permission: %s%s  Target: %s", LINE_SEPARATOR,permission.getPermissionName(), LINE_SEPARATOR,player.getName()));
+        CustomCrafter.getInstance().getLogger().info(String.format("Permission added: %s  Permission: %s%s  Target: %s", LINE_SEPARATOR,permission.getPermissionName(), LINE_SEPARATOR,player.getName()));
         displayPlayerPermissions(uuid,sender);
     }
 
@@ -44,7 +45,7 @@ public class PermissionCheck {
         UUID uuid = player.getUniqueId();
         if (!PLAYER_PERMISSIONS.containsKey(uuid)) return;
         RecipePermission permission = RECIPE_PERMISSION_MAP.get(perm);
-        Bukkit.getLogger().info(String.format("Permission removed: %s  Permission: %s%s  Target: %s", LINE_SEPARATOR,permission.getPermissionName(), LINE_SEPARATOR,player.getName()));
+        CustomCrafter.getInstance().getLogger().info(String.format("Permission removed: %s  Permission: %s%s  Target: %s", LINE_SEPARATOR,permission.getPermissionName(), LINE_SEPARATOR,player.getName()));
         PLAYER_PERMISSIONS.get(uuid).remove(permission);
         displayPlayerPermissions(uuid,sender);
     }
@@ -61,7 +62,7 @@ public class PermissionCheck {
         builder.append("=== RecipePermissions (The player has) ==="+ LINE_SEPARATOR);
         if(!PLAYER_PERMISSIONS.containsKey(uuid)) {
             builder.append(String.format("Target player has no permissions.%s", LINE_SEPARATOR));
-            Bukkit.getLogger().info(builder.toString());
+            CustomCrafter.getInstance().getLogger().info(builder.toString());
             return;
         }
 

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/command/Processor.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/command/Processor.java
@@ -114,15 +114,15 @@ public class Processor implements CommandExecutor, TabCompleter {
         }
 
         if (id == -1) {
-            sender.sendMessage("[CustomCrafter] This command is not a correct one.");
+            sender.sendMessage("This command is not a correct one.");
             return false;
         } else if (!(sender instanceof Player) && 100 < id) {
-            sender.sendMessage("[CustomCrafter] You cannot use this command from other than as a player.");
+            sender.sendMessage("You cannot use this command from other than as a player.");
             return false;
         }
 
         if (sender instanceof Player && !hasCorrectPermission((Player) sender, id)) {
-            sender.sendMessage("[CustomCrafter] You do not have enough permissions to use this command.");
+            sender.sendMessage("You do not have enough permissions to use this command.");
             return false;
         }
 

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/listener/Listener.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/listener/Listener.java
@@ -1,6 +1,7 @@
 package com.github.sakakiaruka.customcrafter.customcrafter.listener;
 
 import com.destroystokyo.paper.event.player.PlayerUseUnknownEntityEvent;
+import com.github.sakakiaruka.customcrafter.customcrafter.CustomCrafter;
 import com.github.sakakiaruka.customcrafter.customcrafter.SettingsLoad;
 import com.github.sakakiaruka.customcrafter.customcrafter.command.Check;
 import io.papermc.paper.event.server.ServerResourcesReloadedEvent;
@@ -37,7 +38,7 @@ public class Listener implements org.bukkit.event.Listener {
 
     @EventHandler
     public void consume(PlayerUseUnknownEntityEvent event) {
-        Bukkit.getLogger().info(event.toString());
+        CustomCrafter.getInstance().getLogger().info(event.toString());
     }
 
     @EventHandler

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/search/Search.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/search/Search.java
@@ -1,5 +1,6 @@
 package com.github.sakakiaruka.customcrafter.customcrafter.search;
 
+import com.github.sakakiaruka.customcrafter.customcrafter.CustomCrafter;
 import com.github.sakakiaruka.customcrafter.customcrafter.object.Matter.Container.ContainerType;
 import com.github.sakakiaruka.customcrafter.customcrafter.object.Matter.Container.MatterContainer;
 import com.github.sakakiaruka.customcrafter.customcrafter.object.Matter.EnchantStrict;
@@ -235,12 +236,12 @@ public class Search {
             try {
                 Matcher m = Pattern.compile(PASS_THROUGH_PATTERN).matcher(recipe.getResult().getNameOrRegex());
                 if (!m.matches()) {
-                    Bukkit.getLogger().warning("[CustomCrafter] pass-through mode failed. (Illegal Material name.)");
+                    CustomCrafter.getInstance().getLogger().warning("pass-through mode failed. (Illegal Material name.)");
                     return;
                 }
                 target = Material.valueOf(m.group(1).toUpperCase());
             } catch (Exception e) {
-                Bukkit.getLogger().warning("[CustomCrafter] pass-through mode failed. (Illegal Material name.)");
+                CustomCrafter.getInstance().getLogger().warning("pass-through mode failed. (Illegal Material name.)");
                 return;
             }
             List<ItemStack> items = new ArrayList<>();
@@ -249,7 +250,7 @@ public class Search {
                 if (inventory.getItem(i).getType().equals(target)) items.add(inventory.getItem(i));
             }
             if (items.size() != 1) {
-                Bukkit.getLogger().warning("[CustomCrafter] pass-through mode failed. (Same material some where.) ");
+                CustomCrafter.getInstance().getLogger().warning("pass-through mode failed. (Same material some where.) ");
                 return;
             }
 

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/util/ContainerUtil.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/util/ContainerUtil.java
@@ -248,16 +248,16 @@ public class ContainerUtil {
     }
 
     private static void sendIllegalTemplateWarn(String type, String source, String pattern) {
-        Bukkit.getLogger().warning(String.format("%s===%s[Custom Crafter] Illegal %s pattern. (%s)", SettingsLoad.LINE_SEPARATOR,SettingsLoad.LINE_SEPARATOR, type, source));
-        Bukkit.getLogger().warning(String.format("[Custom Crafter] The source pattern is %s.%s===", pattern, SettingsLoad.LINE_SEPARATOR));
+        CustomCrafter.getInstance().getLogger().warning(String.format("%s===%s[Custom Crafter] Illegal %s pattern. (%s)", SettingsLoad.LINE_SEPARATOR,SettingsLoad.LINE_SEPARATOR, type, source));
+        CustomCrafter.getInstance().getLogger().warning(String.format("[Custom Crafter] The source pattern is %s.%s===", pattern, SettingsLoad.LINE_SEPARATOR));
     }
 
     private static void sendNoSuchTemplateWarn(String type, String source) {
-        Bukkit.getLogger().warning(String.format("%s===%s[Custom Crafter] No such %s. (%s)%s===", SettingsLoad.LINE_SEPARATOR,SettingsLoad.LINE_SEPARATOR, type, source, SettingsLoad.LINE_SEPARATOR));
+        CustomCrafter.getInstance().getLogger().warning(String.format("%s===%s[Custom Crafter] No such %s. (%s)%s===", SettingsLoad.LINE_SEPARATOR,SettingsLoad.LINE_SEPARATOR, type, source, SettingsLoad.LINE_SEPARATOR));
     }
 
     public static void sendOrdinalWarn(String warn) {
-        Bukkit.getLogger().warning(String.format("%s===%s[Custom Crafter] %s%s===", SettingsLoad.LINE_SEPARATOR, SettingsLoad.LINE_SEPARATOR, warn, SettingsLoad.LINE_SEPARATOR));
+        CustomCrafter.getInstance().getLogger().warning(String.format("%s===%s[Custom Crafter] %s%s===", SettingsLoad.LINE_SEPARATOR, SettingsLoad.LINE_SEPARATOR, warn, SettingsLoad.LINE_SEPARATOR));
     }
 
     public static final TriConsumer<Map<String, String>, ItemStack, String> LORE = (data, item, formula) -> {

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/util/EntityUtil.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/util/EntityUtil.java
@@ -272,7 +272,7 @@ public class EntityUtil {
                     int weight = CalcUtil.getRandomNumber(numSource, 1, MAX_SPAWN_WEIGHT);
                     spawner.addPotentialSpawn(new SpawnerEntry(base.createSnapshot(), weight, rule));
 
-                    Bukkit.getLogger().info(
+                    CustomCrafter.getInstance().getLogger().info(
                             "Spawner Setup done." + SettingsLoad.LINE_SEPARATOR +
                                     "Location: " + spawner.getLocation() + SettingsLoad.LINE_SEPARATOR +
                                     "  - require min block light: " + rule.getMinBlockLight() + SettingsLoad.LINE_SEPARATOR +

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/util/InventoryUtil.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/util/InventoryUtil.java
@@ -1,5 +1,6 @@
 package com.github.sakakiaruka.customcrafter.customcrafter.util;
 
+import com.github.sakakiaruka.customcrafter.customcrafter.CustomCrafter;
 import com.github.sakakiaruka.customcrafter.customcrafter.object.Matter.Matter;
 import com.github.sakakiaruka.customcrafter.customcrafter.object.Matter.Potions.Potions;
 import com.github.sakakiaruka.customcrafter.customcrafter.object.Recipe.*;
@@ -112,7 +113,7 @@ public class InventoryUtil {
 
     private static boolean isValidCharacters(BookMeta meta, String value, String section) {
         if (25600 < (meta.getPageCount() * 320) + value.length()) {
-            Bukkit.getLogger().warning("[CustomCrafter] Set result metadata (" + section + ") failed. (Over 25600 characters.)");
+            CustomCrafter.getInstance().getLogger().warning("Set result metadata (" + section + ") failed. (Over 25600 characters.)");
             return false;
         }
         return true;
@@ -130,8 +131,8 @@ public class InventoryUtil {
             try {
                 value = String.join(LINE_SEPARATOR, Files.readAllLines(Paths.get(value), StandardCharsets.UTF_8));
             } catch (Exception e) {
-                Bukkit.getLogger().warning("[CustomCrafter] Set result metadata (addLong - extend) failed. (About a file read.)");
-                Bukkit.getLogger().warning(e.getMessage());
+                CustomCrafter.getInstance().getLogger().warning("Set result metadata (addLong - extend) failed. (About a file read.)");
+                CustomCrafter.getInstance().getLogger().warning(e.getMessage());
                 return;
             }
         }
@@ -139,7 +140,7 @@ public class InventoryUtil {
         if (!isValidCharacters(meta, value, section)) return;
 
         if (ONE_BOOK_CHAR_LIMIT < value.length()) {
-            Bukkit.getLogger().warning("[CustomCrafter] Set result metadata (addLong) failed. (Over 25600 characters.)");
+            CustomCrafter.getInstance().getLogger().warning("Set result metadata (addLong) failed. (Over 25600 characters.)");
             meta.addPages(Component.text("Overflown"));
             return;
         }
@@ -159,8 +160,8 @@ public class InventoryUtil {
                 // make a new page
 
                 if (meta.getPageCount() == 100) {
-                    Bukkit.getLogger().warning("[CustomCrafter] Set result metadata (addLong) failed. (Over 100 pages.)");
-                    Bukkit.getLogger().warning("[CustomCrafter] Remaining " + (element.capacity() + (value.length() - i)) + " characters.");
+                    CustomCrafter.getInstance().getLogger().warning("Set result metadata (addLong) failed. (Over 100 pages.)");
+                    CustomCrafter.getInstance().getLogger().warning("Remaining " + (element.capacity() + (value.length() - i)) + " characters.");
                     return;
                 }
 
@@ -214,7 +215,7 @@ public class InventoryUtil {
             case "WHITE" -> color = Color.WHITE;
             case "YELLOW" -> color = Color.YELLOW;
             default -> {
-                Bukkit.getLogger().warning("[CustomCrafter] (ColorName) failed. Input -> " + value);
+                CustomCrafter.getInstance().getLogger().warning("(ColorName) failed. Input -> " + value);
                 return null;
             }
         }
@@ -275,7 +276,7 @@ public class InventoryUtil {
             }
         }
 
-//        Bukkit.getLogger().info("merged map="+merged);
+//        CustomCrafter.getInstance().getLogger().info("merged map="+merged);
 
         Map<Coordinate, List<Coordinate>> conflict = new HashMap<>();
         Map<Coordinate, Coordinate> finished = new HashMap<>();
@@ -286,18 +287,18 @@ public class InventoryUtil {
                     continue;
                 }
                 // finished has already contained this value
-//                Bukkit.getLogger().info("combination error (value duplication)");
+//                CustomCrafter.getInstance().getLogger().info("combination error (value duplication)");
                 return new HashMap<>();
             }
 
             conflict.put(entry.getKey(), entry.getValue());
         }
 
-//        Bukkit.getLogger().info("finished="+finished);
-//        Bukkit.getLogger().info("conflict="+conflict);
+//        CustomCrafter.getInstance().getLogger().info("finished="+finished);
+//        CustomCrafter.getInstance().getLogger().info("conflict="+conflict);
 
         if (hasDuplicate(finished)) {
-//            Bukkit.getLogger().info("contains duplicate coordinate.");
+//            CustomCrafter.getInstance().getLogger().info("contains duplicate coordinate.");
             return new HashMap<>();
         }
 
@@ -330,7 +331,7 @@ public class InventoryUtil {
             non_duplicate.add(Arrays.toString(ss));
         }
 
-//        Bukkit.getLogger().info("non_duplicate="+non_duplicate);
+//        CustomCrafter.getInstance().getLogger().info("non_duplicate="+non_duplicate);
 
         List<String> non_duplcicate_list = new ArrayList<>(non_duplicate);
         for (int i = 0; i < non_duplcicate_list.size(); i++) {
@@ -340,7 +341,7 @@ public class InventoryUtil {
                 Coordinate key = entry.getKey();
 
                 // debug
-//                Bukkit.getLogger().info("conflict loop (i="+i+", temp[index])="+temp[index]);
+//                CustomCrafter.getInstance().getLogger().info("conflict loop (i="+i+", temp[index])="+temp[index]);
 
                 String indexParse = temp[index]
                         .replace("[", "")
@@ -359,15 +360,15 @@ public class InventoryUtil {
             }
 
             if (hasDuplicate(finished)) {
-//                Bukkit.getLogger().info("contains duplicate coordinate (in loop)");
+//                CustomCrafter.getInstance().getLogger().info("contains duplicate coordinate (in loop)");
                 continue;
             }
 
-//            Bukkit.getLogger().info("finished (index="+index+")="+finished);
+//            CustomCrafter.getInstance().getLogger().info("finished (index="+index+")="+finished);
             return finished;
         }
 
-//        Bukkit.getLogger().info("recipe match failed.");
+//        CustomCrafter.getInstance().getLogger().info("recipe match failed.");
         return new HashMap<>();
     }
 

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/util/PotionUtil.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/util/PotionUtil.java
@@ -219,9 +219,9 @@ public class PotionUtil {
                     }
                 }
 
-                Bukkit.getLogger().info(BAR);
-                Bukkit.getLogger().info("[Custom Crafter] Finished creating default potion files.");
-                Bukkit.getLogger().info(BAR);
+                CustomCrafter.getInstance().getLogger().info(BAR);
+                CustomCrafter.getInstance().getLogger().info("[Custom Crafter] Finished creating default potion files.");
+                CustomCrafter.getInstance().getLogger().info(BAR);
 
             }
         }.runTaskAsynchronously(getInstance());


### PR DESCRIPTION
- logger change
`Bukkit.getLogger()` -> `CustomCrafter.getInstance().getLogger()`
Bukkit.getLogger() has been labeled `@Internal`. ( [(Paper JavaDoc) Bukkit.getLogger()](https://jd.papermc.io/paper/1.20.6/org/bukkit/Bukkit.html#getLogger()) )

---

- remove log prefix
`getLogger().info("[CustomCrafter] ~~~");` -> `getLogger().info("~~~");`
Hardcorded plugin name's prefix duplicates with logger's suffix.