### PR TITLE
support 1.21.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <version>1.21.3-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/SettingsLoad.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/SettingsLoad.java
@@ -720,8 +720,8 @@ public class SettingsLoad {
             case "amount" -> consumer = ContainerUtil.AMOUNT;
             case "set_storage_item" -> consumer = ContainerUtil.SET_STORAGE_ITEM;
             case "item_define" -> consumer = ContainerUtil.ITEM_DEFINE;
-            case "can_place_on" -> consumer = ContainerUtil.CAN_PLACE_ON;
-            case "can_destroy" -> consumer = ContainerUtil.CAN_DESTROY;
+//            case "can_place_on" -> consumer = ContainerUtil.CAN_PLACE_ON;
+//            case "can_destroy" -> consumer = ContainerUtil.CAN_DESTROY;
             case "repair_cost" -> consumer = ContainerUtil.REPAIR_COST;
             case "enchant_book" -> consumer = ContainerUtil.ENCHANT_BOOK;
             case "firework" -> consumer = ContainerUtil.FIREWORK;

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/object/Matter/Potions/Potions.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/object/Matter/Potions/Potions.java
@@ -8,7 +8,7 @@ import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
-import org.bukkit.potion.PotionData;
+//import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
@@ -38,27 +38,32 @@ public class Potions extends Matter implements Matters {
                 map.put(effect,strict);
             }
         }
-        PotionData baseData = meta.getBasePotionData();
-        PotionUtil util = new PotionUtil();
-        if(meta.getBasePotionData().getType().equals(PotionType.TURTLE_MASTER)){
-            int duration = PotionUtil.getDuration("turtle_master",baseData.isUpgraded(),baseData.isExtended(),util.getBottleType(item.getType()));
-            int slowLevel = baseData.isUpgraded() ? 6 : 4;
-            int resistanceLevel = baseData.isUpgraded() ? 4 : 3;
-            PotionEffect slow = new PotionEffect(PotionEffectType.SLOW,duration,slowLevel);
-            PotionEffect resistance = new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE,duration,resistanceLevel);
-            map.put(slow,strict);
-            map.put(resistance,strict);
+//        PotionData baseData = meta.getBasePotionData();
+//        PotionUtil util = new PotionUtil();
+//        if(meta.getBasePotionData().getType().equals(PotionType.TURTLE_MASTER)){
+//            int duration = PotionUtil.getDuration("turtle_master",baseData.isUpgraded(),baseData.isExtended(),util.getBottleType(item.getType()));
+//            int slowLevel = baseData.isUpgraded() ? 6 : 4;
+//            int resistanceLevel = baseData.isUpgraded() ? 4 : 3;
+//            PotionEffect slow = new PotionEffect(PotionEffectType.SLOW,duration,slowLevel);
+//            PotionEffect resistance = new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE,duration,resistanceLevel);
+//            map.put(slow,strict);
+//            map.put(resistance,strict);
+//
+//        } else if(!baseData.getType().equals(PotionType.WATER) && !baseData.getType().equals(PotionType.UNCRAFTABLE)){
+//            int duration = util.getDuration(baseData.getType().getEffectType().getName(), baseData.isUpgraded(), baseData.isExtended(),util.getBottleType(item.getType()));
+//            int level = baseData.isUpgraded() ? baseData.getType().getMaxLevel() : 1;
+//            PotionEffect effect = new PotionEffect(baseData.getType().getEffectType(),duration,level);
+//            map.put(effect,strict);
+//        } else {
+//            for(PotionEffect effect : meta.getCustomEffects()){
+//                map.put(effect,strict);
+//            }
+//        }
 
-        } else if(!baseData.getType().equals(PotionType.WATER) && !baseData.getType().equals(PotionType.UNCRAFTABLE)){
-            int duration = util.getDuration(baseData.getType().getEffectType().getName(), baseData.isUpgraded(), baseData.isExtended(),util.getBottleType(item.getType()));
-            int level = baseData.isUpgraded() ? baseData.getType().getMaxLevel() : 1;
-            PotionEffect effect = new PotionEffect(baseData.getType().getEffectType(),duration,level);
+        for(PotionEffect effect : meta.getCustomEffects()){
             map.put(effect,strict);
-        } else {
-            for(PotionEffect effect : meta.getCustomEffects()){
-                map.put(effect,strict);
-            }
         }
+
         data = map;
         bottle = PotionUtil.getBottleType(item.getType());
 
@@ -66,18 +71,18 @@ public class Potions extends Matter implements Matters {
         bottleTypeMatch = true;
     }
 
-    public ItemStack prescribe(){
-        ItemStack result = new ItemStack(bottle.getRelated());
-        PotionMeta meta = (PotionMeta) result.getItemMeta();
-
-        PotionData baseData = new PotionData(PotionType.WATER);
-        meta.setBasePotionData(baseData);
-        for(Map.Entry<PotionEffect,PotionStrict> entry : data.entrySet()){
-            meta.addCustomEffect(entry.getKey(),true);
-        }
-        result.setItemMeta(meta);
-        return result;
-    }
+//    public ItemStack prescribe(){
+//        ItemStack result = new ItemStack(bottle.getRelated());
+//        PotionMeta meta = (PotionMeta) result.getItemMeta();
+//
+//        PotionData baseData = new PotionData(PotionType.WATER);
+//        meta.setBasePotionData(baseData);
+//        for(Map.Entry<PotionEffect,PotionStrict> entry : data.entrySet()){
+//            meta.addCustomEffect(entry.getKey(),true);
+//        }
+//        result.setItemMeta(meta);
+//        return result;
+//    }
 
     public String PotionInfo(){
         StringBuilder builder = new StringBuilder();

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/util/EntityUtil.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/util/EntityUtil.java
@@ -9,6 +9,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
+import org.bukkit.Registry;
 import org.bukkit.World;
 import org.bukkit.attribute.Attributable;
 import org.bukkit.attribute.Attribute;
@@ -29,6 +30,7 @@ import org.bukkit.entity.Mob;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.EquipmentSlotGroup;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
@@ -571,13 +573,18 @@ public class EntityUtil {
         Matcher parsed = Pattern.compile(pattern).matcher(formula);
         if (!parsed.matches()) return;
         if (parsed.group(2) != null && !Boolean.parseBoolean(parsed.group(2))) return;
-        Attribute attribute = Attribute.valueOf(parsed.group(3).toUpperCase());
+        //Attribute attribute = Attribute.valueOf(parsed.group(3).toUpperCase());
+        Attribute attribute;
+        if ((attribute = Registry.ATTRIBUTE.get(NamespacedKey.minecraft(parsed.group(2).toUpperCase()))) == null) return;
         AttributeModifier.Operation operation = AttributeModifier.Operation.valueOf(parsed.group(4).toUpperCase());
         double value = Double.parseDouble(parsed.group(5));
-        EquipmentSlot slot = parsed.group(6) != null ? EquipmentSlot.valueOf(parsed.group(6)) : null;
+        //EquipmentSlot slot = parsed.group(6) != null ? EquipmentSlot.valueOf(parsed.group(6)) : null;
+        EquipmentSlotGroup group = EquipmentSlotGroup.getByName(parsed.group(6).toUpperCase());
         AttributeModifier modifier;
-        if (slot != null) modifier = new AttributeModifier(UUID.randomUUID(), UUID.randomUUID().toString(), value, operation, slot);
-        else modifier = new AttributeModifier(UUID.randomUUID(), UUID.randomUUID().toString(), value, operation);
+        //if (slot != null) modifier = new AttributeModifier(UUID.randomUUID(), UUID.randomUUID().toString(), value, operation, slot);
+        NamespacedKey randomNamespacedKey = new NamespacedKey(CustomCrafter.getInstance(), UUID.randomUUID().toString());
+        if (group != null) modifier = new AttributeModifier(randomNamespacedKey, value, operation, group);
+        else modifier = new AttributeModifier(randomNamespacedKey, value, operation);
 
         AttributeInstance instance;
         if ((instance = ((Attributable) base).getAttribute(attribute)) == null) {

--- a/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/util/PotionUtil.java
+++ b/src/main/java/com/github/sakakiaruka/customcrafter/customcrafter/util/PotionUtil.java
@@ -20,7 +20,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.io.IOException;;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;


### PR DESCRIPTION
内部更新
- AttributeModifier コンストラクタの更新
- PotionData 系の廃止

利用者側に波及する更新
- AttributeModifierEquipment のスロット指定方法 (EquipmentSlot -> EquipmentSlotGroup)
- canPlaceOn, canDestroy の仮廃止（PaperAPI の対応が完了し次第再整備予定）