### PR TITLE
Filter type fix (like v5.0.8-1)

### DIFF
--- a/src/main/java/io/github/sakaki_aruka/customcrafter/api/interfaces/filter/CRecipeFilter.kt
+++ b/src/main/java/io/github/sakaki_aruka/customcrafter/api/interfaces/filter/CRecipeFilter.kt
@@ -10,16 +10,11 @@ import org.bukkit.inventory.meta.ItemMeta
 /**
  * candidate filters for [CRecipe].
  *
- * if you want to implement this, recommended to show implementation of [EnchantFilter] more some default filters.
+ * If you want to implement this, recommended to show implementation of [EnchantFilter] more some default filters.
  *
- * you have to set a class what is a subtype of [CMatter] to generic type [T].
+ * [T] must be a subtype of [CMatter].
  *
- * you can set custom [CMatter] implemented class to [T].
- *
- * you do not use 'internal' or 'private' visibility modifier to classes what implements this interface.
- *
- *
- * @param[T] a type of target class or interface. subtype of [CMatter].
+ * @param[T] a type of target class or interface.
  * @since 5.0.6
  */
 interface CRecipeFilter<out T: CMatter> {

--- a/src/main/java/io/github/sakaki_aruka/customcrafter/api/interfaces/recipe/CRecipe.kt
+++ b/src/main/java/io/github/sakaki_aruka/customcrafter/api/interfaces/recipe/CRecipe.kt
@@ -18,7 +18,7 @@ interface CRecipe {
     val items: Map<CoordinateComponent, CMatter>
     val containers: List<CRecipeContainer>?
     val results: List<ResultSupplier>?
-    val filters: Set<CRecipeFilter<*>>?
+    val filters: Set<CRecipeFilter<CMatter>>?
     val type: CRecipeType
     /**
      * replace [items]

--- a/src/main/java/io/github/sakaki_aruka/customcrafter/api/object/recipe/CRecipeImpl.kt
+++ b/src/main/java/io/github/sakaki_aruka/customcrafter/api/object/recipe/CRecipeImpl.kt
@@ -13,7 +13,7 @@ data class CRecipeImpl(
     override val items: Map<CoordinateComponent, CMatter>,
     override val containers: List<CRecipeContainer>? = null,
     override val results: List<ResultSupplier>? = null,
-    override val filters: Set<CRecipeFilter<*>>? = getDefaultFilters(),
+    override val filters: Set<CRecipeFilter<CMatter>>? = getDefaultFilters(),
     override val type: CRecipeType,
 ): CRecipe {
     /**
@@ -36,7 +36,7 @@ data class CRecipeImpl(
          *
          * @return[[Set]<[CRecipeFilter]>] a set of default filters
          */
-        fun getDefaultFilters(): Set<CRecipeFilter<*>> {
+        fun getDefaultFilters(): Set<CRecipeFilter<CMatter>> {
             return setOf(
                 EnchantFilter,
                 EnchantStorageFilter,

--- a/src/main/java/io/github/sakaki_aruka/customcrafter/api/object/recipe/filter/EnchantFilter.kt
+++ b/src/main/java/io/github/sakaki_aruka/customcrafter/api/object/recipe/filter/EnchantFilter.kt
@@ -9,10 +9,10 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 
 /**
- * @suppress
+ * A default [CEnchantMatter] filter implementation.
  * @since 5.0.6
  */
-internal object EnchantFilter: CRecipeFilter<CEnchantMatter> {
+object EnchantFilter: CRecipeFilter<CEnchantMatter> {
     override fun metaTypeCheck(meta: ItemMeta): Boolean = true
 
     override fun normal(

--- a/src/main/java/io/github/sakaki_aruka/customcrafter/api/object/recipe/filter/EnchantStorageFilter.kt
+++ b/src/main/java/io/github/sakaki_aruka/customcrafter/api/object/recipe/filter/EnchantStorageFilter.kt
@@ -8,10 +8,10 @@ import org.bukkit.inventory.meta.EnchantmentStorageMeta
 import org.bukkit.inventory.meta.ItemMeta
 
 /**
- * @suppress
+ * A default [CEnchantmentStoreMatter] filter implementation.
  * @since 5.0.6
  */
-internal object EnchantStorageFilter: CRecipeFilter<CEnchantmentStoreMatter> {
+object EnchantStorageFilter: CRecipeFilter<CEnchantmentStoreMatter> {
     override fun metaTypeCheck(meta: ItemMeta): Boolean {
         return meta is EnchantmentStorageMeta
     }

--- a/src/main/java/io/github/sakaki_aruka/customcrafter/api/object/recipe/filter/PotionFilter.kt
+++ b/src/main/java/io/github/sakaki_aruka/customcrafter/api/object/recipe/filter/PotionFilter.kt
@@ -9,10 +9,10 @@ import org.bukkit.inventory.meta.PotionMeta
 import org.bukkit.potion.PotionEffect
 
 /**
- * @suppress
+ * A default [CPotionMatter] filter implementation.
  * @since 5.0.6
  */
-internal object PotionFilter: CRecipeFilter<CPotionMatter> {
+object PotionFilter: CRecipeFilter<CPotionMatter> {
     override fun metaTypeCheck(meta: ItemMeta): Boolean {
         return meta is PotionMeta
     }

--- a/src/main/java/io/github/sakaki_aruka/customcrafter/api/search/Search.kt
+++ b/src/main/java/io/github/sakaki_aruka/customcrafter/api/search/Search.kt
@@ -246,21 +246,14 @@ object Search {
             if (!recipeOne.predicatesResult(inOne, mapped, recipe, crafterID)) return false
             recipe.filters?.let { set ->
                 for (filter in set) {
-                    try {
-                        val (type, result) = applyNormalFilters(inOne, recipeOne, filter)
-                        return when (type) {
-                            CRecipeFilter.ResultType.NOT_REQUIRED -> continue
-                            CRecipeFilter.ResultType.FAILED -> false
-                            CRecipeFilter.ResultType.SUCCESS -> {
-                                if (result) continue
-                                else false
-                            }
+                    val (type, result) = applyNormalFilters(inOne, recipeOne, filter) ?: continue
+                    return when (type) {
+                        CRecipeFilter.ResultType.NOT_REQUIRED -> continue
+                        CRecipeFilter.ResultType.FAILED -> false
+                        CRecipeFilter.ResultType.SUCCESS -> {
+                            if (result) continue
+                            else false
                         }
-                    } catch (e: ClassCastException) {
-                        continue
-                    } catch (e: Exception) {
-                        e.printStackTrace()
-                        return false
                     }
                 }
             }
@@ -270,10 +263,10 @@ object Search {
 
     private inline fun <reified T: CMatter> applyNormalFilters(
         item: ItemStack,
-        matter: T,
+        matter: CMatter,
         filter: CRecipeFilter<T>
-    ): Pair<CRecipeFilter.ResultType, Boolean> {
-        return filter.normal(item, matter)
+    ): Pair<CRecipeFilter.ResultType, Boolean>? {
+        return if (matter !is T) null else filter.normal(item, matter)
     }
 
     private fun candidateAmorphous(


### PR DESCRIPTION
# What is this?
Mainly internal change.
## CRecipe.filters type changed.
`Set<CRecipeFilter<*>>?` to `Set<CRecipeFilter<CMatter>>?`

## Unsafe logic fixed.
In `Search.kt`. 

---

And default matter filter's document added.